### PR TITLE
Allow relative paths for --listener and --executorFactory option

### DIFF
--- a/interpreter.js
+++ b/interpreter.js
@@ -539,10 +539,13 @@ if (listener) {
 
 var exeFactory = null;
 if (argv.executorFactory) {
+  var resolved_path = null;
   try {
-    exeFactory = require(argv.executorFactory);
+    resolved_path = pathLib.resolve(argv.executorFactory);
+    exeFactory = require(resolved_path);
   } catch (e) {
-    console.error('Unable to load executor factory module ' + argv.executorFactory + ': ' + e);
+    console.error('Unable to load executor factory module from: "' + resolved_path + '": ' + e);
+    resolved_path = null;
     process.exit(78);
   }
 }


### PR DESCRIPTION
Make use of _node's_ `path` module to resolve the given _path_ for `--listener` and `--executorFactory` option before the attempt to `require` them as modules. This should fix Zarkonnen/se-interpreter#10.

Maybe you want to have a look.

This request also includes a few fixes for some _jshint_ issues (in a separate commit), namely
- trailing white-spaces
- semicolon related
- _strict_-equality

regards
~david
