### PR TITLE
style(interpreter): fix colored output

### DIFF
--- a/interpreter.js
+++ b/interpreter.js
@@ -359,7 +359,7 @@ function getInterpreterListener(testRun) {
   return {
     'startTestRun': function(testRun, info) {
       if (info.success) {
-        console.log(testRun.name + ": " + "Starting test ".green +" ("+ testRun.browserOptions.browserName +") ".yellow + testRun.name );
+        console.log(testRun.name + ": " + "Starting test ".green +("("+ testRun.browserOptions.browserName +") ").yellow + testRun.name );
       } else {
         console.log(testRun.name + ": " + "Unable to start test ".red + testRun.name + ": " + util.inspect(info.error));
       }


### PR DESCRIPTION
This will fix a minor issue with colored output when running tests where only the right paren was colored in yellow.
