### PR TITLE
docs(interpreter): fix typo in api documentation

### DIFF
--- a/interpreter.js
+++ b/interpreter.js
@@ -291,7 +291,7 @@ TestRun.prototype.p = function(name) {
  * @param args List of arguments.
  * @param callback stepCallback that's invoked by default.
  * @param successCallback If specified, called on success instead of calling callback.
- * @param failureCallback If specified, called on success instead of calling callback.
+ * @param failureCallback If specified, called on error instead of calling callback.
  */
 TestRun.prototype.do = function(fName, args, callback, successCallback, failureCallback) {
   if (!this.wd[fName]) {
@@ -324,7 +324,7 @@ TestRun.prototype.do = function(fName, args, callback, successCallback, failureC
  * @param locatorName Name of the locator step parameter, usually "locator".
  * @param callback stepCallback that's invoked by default.
  * @param successCallback If specified, called on success instead of calling callback.
- * @param failureCallback If specified, called on success instead of calling callback.
+ * @param failureCallback If specified, called on error instead of calling callback.
  */
 TestRun.prototype.locate = function(locatorName, callback, successCallback, failureCallback) {
   var locator = this.currentStep()[locatorName];


### PR DESCRIPTION
Fix for probably _duplicated line(s)_ in api documentation of `interpreter.js` (?)

regards
~david
