### PR TITLE
Add step types: moveMouseByOffset leftClick rightClick

### DIFF
--- a/interpreter.js
+++ b/interpreter.js
@@ -323,7 +323,9 @@ TestRun.prototype.p = function(name) {
 
 TestRun.prototype.sub = function(value) {
   for (var k in this.vars) {
-    value = value.replace(new RegExp("\\$\\{" + k + "\\}", "g"), this.vars[k]);
+    if (value.replace) {
+        value = value.replace(new RegExp("\\$\\{" + k + "\\}", "g"), this.vars[k]);
+    }
   }
   return value;
 };

--- a/step_types/leftClick.js
+++ b/step_types/leftClick.js
@@ -1,0 +1,4 @@
+exports.run = function(tr, cb) {
+  tr.do('click', [0], cb);
+};
+

--- a/step_types/mouseOverElement.js
+++ b/step_types/mouseOverElement.js
@@ -1,5 +1,5 @@
 exports.run = function(tr, cb) {
   tr.locate('locator', cb, function(err, el) {
-    tr.do('moveTo', [el, null, null], cb);
+    tr.do('moveTo', [el], cb);
   });
 };

--- a/step_types/moveMouseByOffset.js
+++ b/step_types/moveMouseByOffset.js
@@ -1,0 +1,4 @@
+exports.run = function(tr, cb) {
+    tr.do('moveTo', [null, tr.p('x'), tr.p('y')], cb);
+};
+

--- a/step_types/rightClick.js
+++ b/step_types/rightClick.js
@@ -1,0 +1,4 @@
+exports.run = function(tr, cb) {
+  tr.do('click', [1], cb);
+};
+


### PR DESCRIPTION
- add step type moveMouseByOffset 
- add step type leftClick 
- add step type rightClick 
- fix calling convention of mouseOverElement
  - if a single argument is passed (an element reference), then the
    default behavior of selenium server is to move to the center of
    that element
  - passing [el, null, null] raises a NullPointerException in the server
- update the interpreter to allow Number arguments by selectively
  calling string.replace on tr.do arguments
