### PR TITLE
Add support for CSV data files

### DIFF
--- a/interpreter.js
+++ b/interpreter.js
@@ -635,7 +635,6 @@ var csvSource = {
       }
     }
     
-    var fileStream = fs.createReadStream(path);
     var rawData = fs.readFileSync(path, "UTF-8").toString();
     var csvConverter = new CSVConverter();
 

--- a/interpreter.js
+++ b/interpreter.js
@@ -25,6 +25,7 @@ var pathLib = require('path');
 var fs = require('fs');
 var colors = require('colors');
 var sax = require('sax');
+var CSVConverter = require('csvtojson').core.Converter;
 
 // Common functionality for assert/verify/waitFor/store step types. Only the code for actually
 // getting the value has to be implemented individually.
@@ -623,7 +624,38 @@ var xmlSource = {
   }
 };
 
-var defaultDataSources = [noneSource, manualSource, jsonSource, xmlSource];
+var csvSource = {
+  name: 'csv',
+  load: function(cfg, scriptPath) {
+    var path = pathLib.resolve(cfg.path);
+    if (scriptPath) {
+      var relPath = pathLib.join(scriptPath, '..', cfg.path);
+      if (fs.existsSync(relPath)) {
+        path = relPath;
+      }
+    }
+    
+    var fileStream = fs.createReadStream(path);
+    var rawData = fs.readFileSync(path, "UTF-8").toString();
+    var csvConverter = new CSVConverter();
+
+    var parseComplete = false;
+    var rowData = [];
+    csvConverter.on("end_parsed", function(jsonObj) {
+      parseComplete = true;
+      rowData = jsonObj;
+    });
+    csvConverter.fromString(rawData, function(err, jsonObj) {
+      if (err) {
+        console.log("Error processing CSV:" + err);
+      }
+    });
+    require('deasync').loopWhile(function(){return !parseComplete;});
+    return rowData;
+  }
+};
+
+var defaultDataSources = [noneSource, manualSource, jsonSource, xmlSource, csvSource];
 
 /**
  * Given a data config and a list of data sources, loads the data rows.

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "optimist": "0.3.5",
     "glob": "3.1.16",
     "colors": "~0.6",
+    "csvtojson": "^0.3.21",
+    "deasync": "^0.1.0",
     "sax": ">= 0.6.1"
   },
   "devDependencies": {}


### PR DESCRIPTION
Selenium Builder supports data files in CSV format, but scripts generated using CSV data files cannot (yet) be run through se-interpreter.

I added a new source handler for type 'csv' using npm libraries 'csvtojson' and 'deasync' to parse the CSV contents.
