### PR TITLE
Adding a way to define a default data source config

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This should start up an instance of Firefox, navigate to [the Selenium Builder s
 You can specify multiple commands:
 
     se-interpreter examples/tests/get.json examples/tests/assertTitle.json
-    
+
 The second one of these tests is intended to fail.
 
 And you can use glob syntax to specify whole directories:
@@ -153,7 +153,8 @@ Using `--listener=`_path-to-listener_, you can specify a module that provides li
 * `startTestRun(testRun, info)` Called when a test run has started.
 * `endTestRun(testRun, info)` Called when a test has completed.
 * `startStep(testRun, step)` Called when a step is about to start.
-* `endStep`(testRun, step, info)` Called when a step has completed.
+* `endStep(testRun, step, info)` Called when a step has completed.
+* `endAllRuns(num_runs, successes)` Called when all tests have completed.
 
 The `info` objects have two keys: `success`, which is `true` or `false`, and `error`, which may contain an exception if `success` is false. The `interpreter` module itself contains a listener implementation which is used as the default listener if `--quiet` or `--silent` is not specified.
 

--- a/interpreter.js
+++ b/interpreter.js
@@ -123,7 +123,7 @@ var TestRun = function(script, name, initialVars) {
 TestRun.prototype.start = function(callback, webDriverToUse) {
   callback = callback || function() {};
   this.browserOptions.name = this.name;
-  
+
   if (webDriverToUse) {
     this.wd = webDriverToUse;
     var info = { 'success': true, 'error': null };
@@ -500,7 +500,7 @@ function parseSuiteFile(path, fileContents, testRuns, silencePrints, listenerFac
       parseScriptFile(scriptLocation.path, null, testRuns, silencePrints, listenerFactory, exeFactory, browserOptions, driverOptions, listenerOptions, dataSources);
     }
   });
-  
+
   if (shareState && testRuns.length > prevTestRunsLength + 1) {
     for (var i = prevTestRunsLength; i < testRuns.length - 1; i++) {
       testRuns[i].quitDriverAfterUse = false;
@@ -815,7 +815,7 @@ function runNext() {
     testRuns[index].shareStateFromPrevTestRun ? testRuns[index - 1].vars : null);
   } else {
     if (index == lastRunFinishedIndex) { // We're the last runner to complete.
-      var listener = listenerFactory();
+      var listener = listenerFactory(testRuns[index-1], listenerOptions);
       if (listener) {
         listener.endAllRuns(testRuns.length, successes);
       }

--- a/interpreter.js
+++ b/interpreter.js
@@ -632,17 +632,25 @@ var defaultDataSources = [noneSource, manualSource, jsonSource, xmlSource];
  * @param scriptPath Optionally, the path of the script we're loading data for, for use in relative paths.
  */
 function loadData(dataConfig, dataSources, scriptPath) {
+  var configSource = 'none';
+  if (dataConfig.source && dataConfig.source != 'none') {
+    configSource = dataConfig.source
+  } else if (defaultDataConfig) {
+    configSource = defaultDataConfig
+  }
+
   if (dataSources) {
-    var sources = dataSources.filter(function(ds) { return ds.name == dataConfig.source; });
+    var sources = dataSources.filter(function(ds) { return ds.name == configSource; });
     if (sources.length > 0) {
-      return sources[0].load(dataConfig.configs[dataConfig.source], scriptPath);
+      console.log('Using Data: ' + configSource);
+      return sources[0].load(dataConfig.configs[configSource], scriptPath);
     }
   }
-  var sources = defaultDataSources.filter(function(ds) { return ds.name == dataConfig.source; });
+  var sources = defaultDataSources.filter(function(ds) { return ds.name == configSource; });
   if (sources.length == 0) {
     throw new Error("No data source of name \"" + dataConfig.source + "\" available.");
   }
-  return sources[0].load(dataConfig.configs[dataConfig.source], scriptPath);
+  return sources[0].load(dataConfig.configs[configSource], scriptPath);
 }
 
 exports.TestRun = TestRun;
@@ -665,6 +673,7 @@ var opt = require('optimist')
   .default('noPrint', false).describe('noPrint', 'no print step output')
   .default('silent', false).describe('silent', 'no non-error output')
   .default('parallel', 1).describe('parallel', 'number of tests to run in parallel')
+  .describe('dataConfig', 'the default dataConfig')
   .describe('dataSource', 'path to data source module')
   .describe('listener', 'path to listener module')
   .describe('executorFactory', 'path to factory for extra type executors')
@@ -726,6 +735,10 @@ if (argv.dataSource) {
       process.exit(78);
     }
   });
+}
+
+if (argv.dataConfig) {
+  var defaultDataConfig = argv.dataConfig;
 }
 
 var listener = null;

--- a/utils/sauce_listener.js
+++ b/utils/sauce_listener.js
@@ -28,7 +28,7 @@ Listener.prototype.endTestRun = function(testRun, info) {
   } else {
     data = JSON.stringify({'passed': info.success});
   }
-  
+
   var options = {
     'hostname': 'saucelabs.com',
     'port': 443,
@@ -37,13 +37,13 @@ Listener.prototype.endTestRun = function(testRun, info) {
     'auth': this.username + ':' + this.accessKey,
     'headers': { 'Content-Type': 'application/json', 'Content-Length': data.length }
   };
-    
+
   var req = https.request(options);
-  
+
   req.on('error', function(e) {
     console.error(e);
   });
-  
+
   req.write(data);
   req.end();
   if (this.originalListener) { this.originalListener.endTestRun(testRun, info); }
@@ -55,6 +55,10 @@ Listener.prototype.startStep = function(testRun, step) {
 
 Listener.prototype.endStep = function(testRun, step, info) {
   if (this.originalListener) { this.originalListener.endStep(testRun, step, info); }
+};
+
+Listener.prototype.endAllRuns = function(num_runs, successes) {
+  if (this.originalListener) { this.originalListener.endAllRuns(num_runs, successes); }
 };
 
 exports.getInterpreterListener = function(testRun, options, interpreter_module) {


### PR DESCRIPTION
I'm using se-interpreter to run automated tests through jenkins.  I needed a way to change which data sources the script use as I test different environments.  This change allows me to specify a default config from the cli.