### PR TITLE
Add a step type to support xxxxElementStyle steps

### DIFF
--- a/step_types/ElementStyle.js
+++ b/step_types/ElementStyle.js
@@ -1,0 +1,8 @@
+exports.cmp = 'value';
+exports.run = function(tr, cb) {
+  tr.locate('locator', cb, function(err, element) {
+    tr.do('getComputedCSS', [element, tr.p('propertyName')], cb, function(err, value) {
+      cb({'value': value});
+    });
+  });
+};


### PR DESCRIPTION
I've creates a new step type to support operations for ElementStyle steps. This is pretty straightforward and invokes the "getComputedCSS" operation of the webdriver.

Hope you may integrate this to master.

Best Regards.